### PR TITLE
[Feature] 회원/게시글 엔티티 및 리포지토리 생성

### DIFF
--- a/src/main/java/com/team4/goorm/community/Member/domain/Member.java
+++ b/src/main/java/com/team4/goorm/community/Member/domain/Member.java
@@ -2,10 +2,13 @@ package com.team4.goorm.community.Member.domain;
 
 import com.team4.goorm.community.global.common.domain.BaseEntity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,5 +20,21 @@ public class Member extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	private Long memberId;
+
+	@Email
+	@Column(nullable = false)
+	private String email;
+
+	@Size(min = 6, max = 20)
+	@Column(nullable = false)
+	private String loginId;
+
+	@Size(min = 2, max = 20)
+	@Column(nullable = false)
+	private String username;
+
+	@Size(min = 8, max = 20)
+	@Column(nullable = false)
+	private String password;
 }

--- a/src/main/java/com/team4/goorm/community/Member/repository/MemberRepository.java
+++ b/src/main/java/com/team4/goorm/community/Member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.team4.goorm.community.Member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.team4.goorm.community.Member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/team4/goorm/community/Post/domain/Category.java
+++ b/src/main/java/com/team4/goorm/community/Post/domain/Category.java
@@ -1,0 +1,43 @@
+package com.team4.goorm.community.Post.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.team4.goorm.community.Post.exception.PostErrorCode;
+import com.team4.goorm.community.Post.exception.PostException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Category {
+
+	C1("카테고리1"),
+	C2("카테고리2"),
+	C3("카테고리3");
+
+	private final String name;
+	private static final Map<String, Category> NAME_TO_ENUM_MAP = new HashMap<>();
+
+	static {
+		for (Category category : Category.values()) {
+			NAME_TO_ENUM_MAP.put(category.name, category);
+		}
+	}
+
+	@JsonValue // 직렬화 시 enum -> name 반환
+	public String getName() {
+		return name;
+	}
+
+	@JsonCreator // 역직렬화 시 name -> enum 반환
+	public static Category fromName(String name) {
+		Category category = NAME_TO_ENUM_MAP.get(name);
+
+		if (category == null) {
+			throw new PostException(PostErrorCode.CATEGORY_NOT_FOUND);
+		}
+		return category;
+	}
+}

--- a/src/main/java/com/team4/goorm/community/Post/domain/Post.java
+++ b/src/main/java/com/team4/goorm/community/Post/domain/Post.java
@@ -1,0 +1,43 @@
+package com.team4.goorm.community.Post.domain;
+
+import com.team4.goorm.community.Member.domain.Member;
+import com.team4.goorm.community.global.common.domain.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Post extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long postId;
+
+	@Size(min = 1, max = 45)
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Category category;
+
+	@ManyToOne
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+}

--- a/src/main/java/com/team4/goorm/community/Post/exception/PostErrorCode.java
+++ b/src/main/java/com/team4/goorm/community/Post/exception/PostErrorCode.java
@@ -1,0 +1,20 @@
+package com.team4.goorm.community.Post.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.team4.goorm.community.global.exception.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PostErrorCode implements BaseErrorCode {
+
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404_0", "존재하지 않는 게시글입니다."),
+	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404_1", "존재하지 않는 카테고리입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/team4/goorm/community/Post/exception/PostException.java
+++ b/src/main/java/com/team4/goorm/community/Post/exception/PostException.java
@@ -1,0 +1,17 @@
+package com.team4.goorm.community.Post.exception;
+
+import org.springframework.http.HttpStatus;
+import lombok.Getter;
+
+@Getter
+public class PostException extends RuntimeException {
+
+	private final HttpStatus status;
+	private final String code;
+
+	public PostException(PostErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.status = errorCode.getHttpStatus();
+		this.code = errorCode.getCode();
+	}
+}

--- a/src/main/java/com/team4/goorm/community/Post/repository/PostRepository.java
+++ b/src/main/java/com/team4/goorm/community/Post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package com.team4.goorm.community.Post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.team4.goorm.community.Post.domain.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#1 

## 💡 작업 내용

회원/게시글 엔티티와 리포지토리 생성했습니다.
카테고리 enum 생성하여 직렬화 및 역직렬화 시 각각 enum -> name, name -> enum으로  반환하게 하였습니다.
post custom exception과 error code 추가하였습니다. (이 부분 다른 엔티티의 경우 건우님 세팅 완료하시면 제가 일괄 추가하도록 하겠습니다.)

## 💬 리뷰 요구사항


